### PR TITLE
Compare bytes with bytes and not str.

### DIFF
--- a/imapcp.py
+++ b/imapcp.py
@@ -145,13 +145,13 @@ class main(ImapUtil):
             # Check for folder in exclusion/inclusion list
             skip = False
             if folder:
-                if folder[0] != srcfolder:
+                if bytes(folder[0], "ascii") != srcfolder:
                     skip = True
                 elif folder[1]:
                     dstfolder = folder[1]
             else:
                 for e in excludes:
-                    if e.match(srcfolder):
+                    if e.match(str(srcfolder)):
                         skip = True
                         break
             if skip:


### PR DESCRIPTION
I have the feeling that there were some mistakes when upgrading from Python 2 to Python 3. Here is a small correction of the comparison of folder names for inclusions and exclusions.